### PR TITLE
Support "Dark mode" in hachoir-wx

### DIFF
--- a/hachoir/wx/hex_view/hex_view.py
+++ b/hachoir/wx/hex_view/hex_view.py
@@ -1,4 +1,5 @@
 import wx
+import darkdetect
 from .file_cache import FileCache
 
 
@@ -168,7 +169,10 @@ class hex_view_t(wx.ScrolledWindow):
 
         # Draw "textbox" rects under the hex and text views
         dc.SetPen(wx.NullPen)
-        dc.SetBrush(wx.WHITE_BRUSH)
+        if darkdetect.isDark():
+            dc.SetBrush(wx.BLACK_BRUSH)
+        else:
+            dc.SetBrush(wx.WHITE_BRUSH)
         dc.DrawRectangle(lo.boxstart('hex'), 0, lo.boxwidth('hex'), h)
         dc.DrawRectangle(lo.boxstart('text'), 0, lo.boxwidth('text'), h)
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,9 @@ def main():
         "extras_require": {
             "urwid": [
                 "urwid==1.3.1"
+            ],
+            "wx": [
+                "darkdetect==0.3.1"
             ]
         },
         "zip_safe": True,


### PR DESCRIPTION
hachoir-wx doesn't currently work well on OSes with dark mode because it sets an explicit colour on the background of the hex editor. This uses the `darkdetect` Python module to determine the correct background colour.